### PR TITLE
Use correct QUrl::fromLocalFile to fix issue #63

### DIFF
--- a/src/filelist.cpp
+++ b/src/filelist.cpp
@@ -295,7 +295,7 @@ int FileList::listDir( const QString& directory, const QStringList& filter, bool
             if( filter.contains(codecName) )
             {
                 QList<QUrl> urls;
-                urls.append("file://" + directory + "/" + fileName);
+                urls.append(QUrl::fromLocalFile(directory + '/' + fileName));
                 addFiles( urls, 0, "", codecName, conversionOptionsId );
             }
 


### PR DESCRIPTION
Wrong use of QUrl did not escape the dash sign correctly when creating
a QUrl object. This fixes the add directory functionality.