### PR TITLE
Make translations work again

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -328,7 +328,7 @@ void Config::load()
         if( QFile::exists(src) && !QFile::exists(dest) )
         {
             QFile::copy(src, dest);
-            logger->log( 1000, i18n("Importing old profiles from: %1").arg(src) );
+            logger->log( 1000, i18n("Importing old profiles from: %1",src) );
         }
     }
 

--- a/src/configdialog/configgeneralpage.cpp
+++ b/src/configdialog/configgeneralpage.cpp
@@ -134,7 +134,7 @@ ConfigGeneralPage::ConfigGeneralPage( Config *_config, QWidget *parent )
     QLabel *lNumFiles = new QLabel( i18n("Number of files to convert at once:"), this );
     numFilesBox->addWidget( lNumFiles );
     iNumFiles = new KIntSpinBox( this );
-    iNumFiles->setToolTip( i18n("You shouldn't set this number higher than the amount of installed processor cores.\nThere have been %1 processor cores detected.").arg(processorsCount) );
+    iNumFiles->setToolTip( i18n("You shouldn't set this number higher than the amount of installed processor cores.\nThere have been %1 processor cores detected.", processorsCount) );
     iNumFiles->setRange( 1, 100 );
     iNumFiles->setValue( config->data.general.numFiles );
     numFilesBox->addWidget( iNumFiles );
@@ -193,7 +193,7 @@ ConfigGeneralPage::ConfigGeneralPage( Config *_config, QWidget *parent )
     QLabel *lNumReplayGainFiles = new QLabel( i18n("Number of items to process at once:"), this );
     numReplayGainFilesBox->addWidget( lNumReplayGainFiles );
     iNumReplayGainFiles = new KIntSpinBox( this );
-    iNumReplayGainFiles->setToolTip( i18n("You shouldn't set this number higher than the amount of installed processor cores.\nThere have been %1 processor cores detected.").arg(processorsCount) );
+    iNumReplayGainFiles->setToolTip( i18n("You shouldn't set this number higher than the amount of installed processor cores.\nThere have been %1 processor cores detected.", processorsCount) );
     iNumReplayGainFiles->setRange( 1, 100 );
     iNumReplayGainFiles->setValue( config->data.general.numReplayGainFiles );
     numReplayGainFilesBox->addWidget( iNumReplayGainFiles );

--- a/src/filelist.cpp
+++ b/src/filelist.cpp
@@ -649,7 +649,7 @@ void FileList::updateItem( FileListItem *item )
         }
         else // shouldn't be possible
         {
-            item->setText( Column_Input, i18n("CD track %1").arg(item->track) );
+            item->setText( Column_Input, i18n("CD track %1",item->track) );
         }
     }
     else

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,7 +9,7 @@
 #include <K4AboutData>
 #include <KCmdLineArgs>
 #include <KLocale>
-
+#include <KLocalizedString>
 
 static const char description[] =
 I18N_NOOP("soundKonverter is a frontend to various audio converters, Replay Gain tools and CD rippers.\n\nPlease file bug reports at https://github.com/dfaust/soundkonverter/issues");
@@ -18,6 +18,8 @@ static const char version[] = SOUNDKONVERTER_VERSION_STRING;
 
 int main(int argc, char **argv)
 {
+    KLocalizedString::setApplicationDomain("soundkonverter");
+    
     K4AboutData about("soundkonverter", 0, ki18n("soundKonverter"), version, ki18n(description), K4AboutData::License_GPL, ki18n("(C) 2005-2017 Daniel Faust"), KLocalizedString(), 0, "hessijames@gmail.com");
     about.addAuthor( ki18n("Daniel Faust"), KLocalizedString(), "hessijames@gmail.com" );
     about.addCredit( ki18n("David Vignoni"), ki18n("Nuvola icon theme"), 0, "http://www.icon-king.com" );

--- a/src/opener/cdopener.cpp
+++ b/src/opener/cdopener.cpp
@@ -553,7 +553,7 @@ QMap<QString,QString> CDOpener::cdDevices()
                 cdDrive = cdda_identify( device.toAscii(), CDDA_MESSAGE_PRINTIT, 0 );
                 if( cdDrive && cdda_open(cdDrive) == 0 )
                 {
-                    const QString desc = i18n("%1 (%2): Audio CD with %3 tracks").arg(name).arg(device).arg(cdda_audio_tracks(cdDrive));
+                    const QString desc = i18n("%1 (%2): Audio CD with %3 tracks",name,device,cdda_audio_tracks(cdDrive));
                     devices.insert( device, desc );
                 }
             }

--- a/src/optionsdetailed.cpp
+++ b/src/optionsdetailed.cpp
@@ -278,7 +278,7 @@ void OptionsDetailed::encoderChanged( const QString& encoder )
     if( !plugin )
     {
 //         TODO leads to crashes
-//         KMessageBox::error( this, i18n("Sorry, this shouldn't happen.\n\nPlease report this bug and attach the following error message:\n\nOptionsDetailed::encoderChanged; PluginLoader::codecPluginByName returned 0 for encoder: '%1'").arg(encoder), i18n("Internal error") );
+//         KMessageBox::error( this, i18n("Sorry, this shouldn't happen.\n\nPlease report this bug and attach the following error message:\n\nOptionsDetailed::encoderChanged; PluginLoader::codecPluginByName returned 0 for encoder: '%1'",encoder), i18n("Internal error") );
         return;
     }
     if( wPlugin )
@@ -319,7 +319,7 @@ void OptionsDetailed::somethingChanged()
     {
         const QString dataRateString = Global::prettyNumber(dataRate,"B");
         lEstimSize->setText( QString(QChar(8776))+" "+dataRateString+" / min." );
-        lEstimSize->setToolTip( i18n("Using the current conversion options will create files with approximately %1 per minute.").arg(dataRateString) );
+        lEstimSize->setToolTip( i18n("Using the current conversion options will create files with approximately %1 per minute.",dataRateString) );
     }
     else
     {

--- a/src/optionseditor.cpp
+++ b/src/optionseditor.cpp
@@ -468,7 +468,7 @@ void OptionsEditor::itemsSelected( QList<FileListItem*> items )
     }
     else // selectedItems.count() > 1
     {
-        setWindowTitle(i18n("%1 Files").arg(selectedItems.count()));
+        setWindowTitle(i18n("%1 Files",selectedItems.count()));
 
         FileListItem *firstItem = selectedItems.first();
         const int     conversionOptionsId = firstItem->conversionOptionsId;

--- a/src/optionssimple.cpp
+++ b/src/optionssimple.cpp
@@ -231,7 +231,7 @@ void OptionsSimple::profileRemove()
 {
     const QString profileName = cProfile->currentText();
 
-    const int ret = KMessageBox::questionYesNo( this, i18n("Do you really want to remove the profile: %1").arg(profileName), i18n("Remove profile?") );
+    const int ret = KMessageBox::questionYesNo( this, i18n("Do you really want to remove the profile: %1",profileName), i18n("Remove profile?") );
     if( ret == KMessageBox::Yes )
     {
         QDomDocument list("soundkonverter_profilelist");
@@ -389,7 +389,7 @@ void OptionsSimple::currentDataRateChanged( int dataRate )
     {
         const QString dataRateString = Global::prettyNumber(dataRate,"B");
         lEstimSize->setText( QString(QChar(8776))+" "+dataRateString+" / min." );
-        lEstimSize->setToolTip( i18n("Using the current conversion options will create files with approximately %1 per minute.").arg(dataRateString) );
+        lEstimSize->setToolTip( i18n("Using the current conversion options will create files with approximately %1 per minute.",dataRateString) );
     }
     else
     {

--- a/src/plugins/soundkonverter_codec_ffmpeg/soundkonverter_codec_ffmpeg.cpp
+++ b/src/plugins/soundkonverter_codec_ffmpeg/soundkonverter_codec_ffmpeg.cpp
@@ -273,7 +273,7 @@ void soundkonverter_codec_ffmpeg::showConfigDialog( ActionType action, const QSt
     if( !configDialog.data() )
     {
         configDialog = new KDialog( parent );
-        configDialog.data()->setCaption( i18n("Configure %1").arg(global_plugin_name)  );
+        configDialog.data()->setCaption( i18n("Configure %1",global_plugin_name) );
         configDialog.data()->setButtons( KDialog::Ok | KDialog::Cancel | KDialog::Default );
 
         QWidget *configDialogWidget = new QWidget( configDialog.data() );

--- a/src/plugins/soundkonverter_codec_fluidsynth/soundkonverter_codec_fluidsynth.cpp
+++ b/src/plugins/soundkonverter_codec_fluidsynth/soundkonverter_codec_fluidsynth.cpp
@@ -82,7 +82,7 @@ void soundkonverter_codec_fluidsynth::showConfigDialog( ActionType action, const
         const int fontHeight = QFontMetrics(QApplication::font()).boundingRect("M").size().height();
 
         configDialog = new KDialog( parent );
-        configDialog.data()->setCaption( i18n("Configure %1").arg(global_plugin_name)  );
+        configDialog.data()->setCaption( i18n("Configure %1",global_plugin_name) );
         configDialog.data()->setButtons( KDialog::Ok | KDialog::Cancel );
 
         QWidget *configDialogWidget = new QWidget( configDialog.data() );

--- a/src/plugins/soundkonverter_codec_lame/soundkonverter_codec_lame.cpp
+++ b/src/plugins/soundkonverter_codec_lame/soundkonverter_codec_lame.cpp
@@ -110,7 +110,7 @@ void soundkonverter_codec_lame::showConfigDialog( ActionType action, const QStri
     if( !configDialog.data() )
     {
         configDialog = new KDialog( parent );
-        configDialog.data()->setCaption( i18n("Configure %1").arg(global_plugin_name)  );
+        configDialog.data()->setCaption( i18n("Configure %1",global_plugin_name) );
         configDialog.data()->setButtons( KDialog::Ok | KDialog::Cancel | KDialog::Default );
 
         QWidget *configDialogWidget = new QWidget( configDialog.data() );
@@ -165,7 +165,7 @@ bool soundkonverter_codec_lame::hasInfo()
 void soundkonverter_codec_lame::showInfo( QWidget *parent )
 {
     KDialog *dialog = new KDialog( parent );
-    dialog->setCaption( i18n("About %1").arg(global_plugin_name)  );
+    dialog->setCaption( i18n("About %1",global_plugin_name) );
     dialog->setButtons( KDialog::Ok );
 
     QLabel *widget = new QLabel( dialog );

--- a/src/plugins/soundkonverter_codec_libav/soundkonverter_codec_libav.cpp
+++ b/src/plugins/soundkonverter_codec_libav/soundkonverter_codec_libav.cpp
@@ -365,7 +365,7 @@ void soundkonverter_codec_libav::showConfigDialog( ActionType action, const QStr
     if( !configDialog.data() )
     {
         configDialog = new KDialog( parent );
-        configDialog.data()->setCaption( i18n("Configure %1").arg(global_plugin_name)  );
+        configDialog.data()->setCaption( i18n("Configure %1",global_plugin_name) );
         configDialog.data()->setButtons( KDialog::Ok | KDialog::Cancel | KDialog::Default );
 
         QWidget *configDialogWidget = new QWidget( configDialog.data() );

--- a/src/plugins/soundkonverter_codec_opustools/soundkonverter_codec_opustools.cpp
+++ b/src/plugins/soundkonverter_codec_opustools/soundkonverter_codec_opustools.cpp
@@ -80,7 +80,7 @@ void soundkonverter_codec_opustools::showConfigDialog( ActionType action, const 
     if( !configDialog.data() )
     {
         configDialog = new KDialog( parent );
-        configDialog.data()->setCaption( i18n("Configure %1").arg(global_plugin_name)  );
+        configDialog.data()->setCaption( i18n("Configure %1",global_plugin_name) );
         configDialog.data()->setButtons( KDialog::Ok | KDialog::Cancel | KDialog::Default );
 
         QWidget *configDialogWidget = new QWidget( configDialog.data() );

--- a/src/plugins/soundkonverter_codec_twolame/soundkonverter_codec_twolame.cpp
+++ b/src/plugins/soundkonverter_codec_twolame/soundkonverter_codec_twolame.cpp
@@ -66,7 +66,7 @@ void soundkonverter_codec_twolame::showConfigDialog( ActionType action, const QS
     Q_UNUSED(parent)
 
 //     KDialog *dialog = new KDialog( parent );
-//     dialog->setCaption( i18n("Configure %1").arg(global_plugin_name)  );
+//     dialog->setCaption( i18n("Configure %1",global_plugin_name) );
 //     dialog->setButtons( KDialog::Ok | KDialog::Cancel | KDialog::Apply );
 
 //     QWidget *widget = new QWidget( dialog );
@@ -89,7 +89,7 @@ bool soundkonverter_codec_twolame::hasInfo()
 void soundkonverter_codec_twolame::showInfo( QWidget *parent )
 {
     KDialog *dialog = new KDialog( parent );
-    dialog->setCaption( i18n("About %1").arg(global_plugin_name)  );
+    dialog->setCaption( i18n("About %1",global_plugin_name) );
     dialog->setButtons( KDialog::Ok );
 
     QLabel *widget = new QLabel( dialog );

--- a/src/plugins/soundkonverter_filter_sox/soundkonverter_filter_sox.cpp
+++ b/src/plugins/soundkonverter_filter_sox/soundkonverter_filter_sox.cpp
@@ -239,7 +239,7 @@ void soundkonverter_filter_sox::showConfigDialog( ActionType action, const QStri
     if( !configDialog.data() )
     {
         configDialog = new KDialog( parent );
-        configDialog.data()->setCaption( i18n("Configure %1").arg(global_plugin_name)  );
+        configDialog.data()->setCaption( i18n("Configure %1",global_plugin_name) );
         configDialog.data()->setButtons( KDialog::Ok | KDialog::Cancel | KDialog::Default );
 
         QWidget *configDialogWidget = new QWidget( configDialog.data() );

--- a/src/plugins/soundkonverter_replaygain_aacgain/soundkonverter_replaygain_aacgain.cpp
+++ b/src/plugins/soundkonverter_replaygain_aacgain/soundkonverter_replaygain_aacgain.cpp
@@ -86,7 +86,7 @@ void soundkonverter_replaygain_aacgain::showConfigDialog( ActionType action, con
     if( !configDialog.data() )
     {
         configDialog = new KDialog( parent );
-        configDialog.data()->setCaption( i18n("Configure %1").arg(global_plugin_name)  );
+        configDialog.data()->setCaption( i18n("Configure %1",global_plugin_name) );
         configDialog.data()->setButtons( KDialog::Ok | KDialog::Cancel | KDialog::Default );
 
         QWidget *configDialogWidget = new QWidget( configDialog.data() );

--- a/src/plugins/soundkonverter_replaygain_mp3gain/soundkonverter_replaygain_mp3gain.cpp
+++ b/src/plugins/soundkonverter_replaygain_mp3gain/soundkonverter_replaygain_mp3gain.cpp
@@ -79,7 +79,7 @@ void soundkonverter_replaygain_mp3gain::showConfigDialog( ActionType action, con
     if( !configDialog.data() )
     {
         configDialog = new KDialog( parent );
-        configDialog.data()->setCaption( i18n("Configure %1").arg(global_plugin_name)  );
+        configDialog.data()->setCaption( i18n("Configure %1",global_plugin_name) );
         configDialog.data()->setButtons( KDialog::Ok | KDialog::Cancel | KDialog::Default );
 
         QWidget *configDialogWidget = new QWidget( configDialog.data() );

--- a/src/plugins/soundkonverter_ripper_cdparanoia/soundkonverter_ripper_cdparanoia.cpp
+++ b/src/plugins/soundkonverter_ripper_cdparanoia/soundkonverter_ripper_cdparanoia.cpp
@@ -79,7 +79,7 @@ void soundkonverter_ripper_cdparanoia::showConfigDialog( ActionType action, cons
     if( !configDialog.data() )
     {
         configDialog = new KDialog( parent );
-        configDialog.data()->setCaption( i18n("Configure %1").arg(global_plugin_name)  );
+        configDialog.data()->setCaption( i18n("Configure %1",global_plugin_name) );
         configDialog.data()->setButtons( KDialog::Ok | KDialog::Cancel | KDialog::Default );
 
         QWidget *configDialogWidget = new QWidget( configDialog.data() );

--- a/src/soundkonverter.cpp
+++ b/src/soundkonverter.cpp
@@ -40,9 +40,9 @@ soundKonverter::soundKonverter()
     const int fontHeight = QFontMetrics(QApplication::font()).boundingRect("M").size().height();
 
     logger = new Logger( this );
-    logger->log( 1000, i18n("This is soundKonverter %1").arg(SOUNDKONVERTER_VERSION_STRING) );
+    logger->log( 1000, i18n("This is soundKonverter %1",SOUNDKONVERTER_VERSION_STRING) );
 
-    logger->log( 1000, "\n" + i18n("Compiled with TagLib %1.%2.%3").arg(TAGLIB_MAJOR_VERSION).arg(TAGLIB_MINOR_VERSION).arg(TAGLIB_PATCH_VERSION) );
+    logger->log( 1000, "\n" + i18n("Compiled with TagLib %1.%2.%3",TAGLIB_MAJOR_VERSION,TAGLIB_MINOR_VERSION,TAGLIB_PATCH_VERSION) );
 
     config = new Config( logger, this );
     config->load();
@@ -258,12 +258,12 @@ void soundKonverter::startupChecks()
         if( QFile::exists(QDir::homePath()+"/.kde4/share/kde4/services/ServiceMenus/convert_with_soundkonverter.desktop") )
         {
             QFile::remove(QDir::homePath()+"/.kde4/share/kde4/services/ServiceMenus/convert_with_soundkonverter.desktop");
-            logger->log( 1000, i18n("Removing old file: %1").arg(QDir::homePath()+"/.kde4/share/kde4/services/ServiceMenus/convert_with_soundkonverter.desktop") );
+            logger->log( 1000, i18n("Removing old file: %1",QDir::homePath()+"/.kde4/share/kde4/services/ServiceMenus/convert_with_soundkonverter.desktop") );
         }
         if( QFile::exists(QDir::homePath()+"/.kde4/share/kde4/services/ServiceMenus/add_replaygain_with_soundkonverter.desktop") )
         {
             QFile::remove(QDir::homePath()+"/.kde4/share/kde4/services/ServiceMenus/add_replaygain_with_soundkonverter.desktop");
-            logger->log( 1000, i18n("Removing old file: %1").arg(QDir::homePath()+"/.kde4/share/kde4/services/ServiceMenus/add_replaygain_with_soundkonverter.desktop") );
+            logger->log( 1000, i18n("Removing old file: %1",QDir::homePath()+"/.kde4/share/kde4/services/ServiceMenus/add_replaygain_with_soundkonverter.desktop") );
         }
     }
 
@@ -278,7 +278,7 @@ void soundKonverter::startupChecks()
         if( *it != "1000.log" && (*it).endsWith(".log") )
         {
             QFile::remove( dir.absolutePath() + "/" + (*it) );
-            logger->log( 1000, i18n("Removing old file: %1").arg(dir.absolutePath()+"/"+(*it)) );
+            logger->log( 1000, i18n("Removing old file: %1",dir.absolutePath()+"/"+(*it)) );
         }
     }
 


### PR DESCRIPTION
Gettext domain was not set, so the translations weren't detected. Added the domain.
The i18n calls no longer like to have .arg() appended. Replaced those.